### PR TITLE
Fixes https://github.com/dav/word2vec/issues/2

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ BIN_DIR=../bin
 
 CC = gcc
 #The -Ofast might not work with older versions of gcc; in that case, use -O2
-CFLAGS = -lm -pthread -O2 -Wall -funroll-loops 
+CFLAGS = -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
 
 all: word2vec word2phrase distance word-analogy compute-accuracy
 


### PR DESCRIPTION
Suppress warning of the scanf unused return value.

Getting a clean (no warnings) compile now:
```
15:23 xxxx 440 word2vec/src> make
gcc word2vec.c -o ../bin/word2vec -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
gcc word2phrase.c -o ../bin/word2phrase -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
gcc distance.c -o ../bin/distance -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
gcc word-analogy.c -o ../bin/word-analogy -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
gcc compute-accuracy.c -o ../bin/compute-accuracy -lm -pthread -O2 -Wall -funroll-loops -Wno-unused-result
chmod +x ../scripts/*.sh
```
