### PR TITLE
The file downloaded is regular zip format, not gzip

### DIFF
--- a/scripts/demo-word.sh
+++ b/scripts/demo-word.sh
@@ -5,6 +5,7 @@ BIN_DIR=../bin
 SRC_DIR=../src
 
 TEXT_DATA=$DATA_DIR/text8
+ZIPPED_TEXT_DATA="${TEXT_DATA}.zip"
 VECTOR_DATA=$DATA_DIR/text8-vector.bin
 
 pushd ${SRC_DIR} && make; popd
@@ -12,8 +13,11 @@ pushd ${SRC_DIR} && make; popd
 if [ ! -e $VECTOR_DATA ]; then
   
   if [ ! -e $TEXT_DATA ]; then
-    wget http://mattmahoney.net/dc/text8.zip -O $DATA_DIR/text8.gz
-    gzip -d $DATA_DIR/text8.gz -f
+    if [ ! -e $ZIPPED_TEXT_DATA ]; then
+	    wget http://mattmahoney.net/dc/text8.zip -O $ZIPPED_TEXT_DATA
+	fi
+    unzip $ZIPPED_TEXT_DATA
+	mv text8 $TEXT_DATA
   fi
   echo -----------------------------------------------------------------------------------------------------
   echo -- Training vectors...


### PR DESCRIPTION
so the `gzip -d` command was barfing.

This switches to using `unzip` instead.

I'm not sure if previously the file was actually a `.gz` misnamed as `.zip` and now it is actually a `.zip` or what.

@arielf making this a PR because wanted to see if you saw a similar issue on linux?