### PR TITLE
Use bash shell in Makefile to get popd, pushd functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 DATA_DIR=./data
 BIN_DIR=./bin
 SRC_DIR=./src


### PR DESCRIPTION
Before this change top-level Makefile was throwing the following error on systems where the default SHELL variable is not set.

```bash
~/github/word2vec$ make build
pushd ./src && make; popd
/bin/sh: 1: pushd: not found
/bin/sh: 1: popd: not found
Makefile:17: recipe for target 'build' failed
make: *** [build] Error 127
```

So I added a simple change to set the default shell to `bash` in the Makefile as suggested by https://stackoverflow.com/a/589300/1385376

Tested on Ubuntu 16.04 and Mac OS 10.x
